### PR TITLE
Use rectangular field rendering for soccer and football

### DIFF
--- a/main.js
+++ b/main.js
@@ -960,7 +960,7 @@ function getRectangularField(centerX, centerY, fieldRadius) {
     const devicePixelRatio = window.devicePixelRatio || 1;
     const canvasWidth = canvas.width / devicePixelRatio;
     const canvasHeight = canvas.height / devicePixelRatio;
-    const canvasAspect = canvasWidth / canvasHeight || 1;
+    const canvasAspect = canvasHeight === 0 ? 1 : canvasWidth / canvasHeight;
 
     // Match canvas aspect ratio while fitting inside the available circular area
     const baseScale = (2 * fieldRadius) / Math.sqrt(canvasAspect * canvasAspect + 1);


### PR DESCRIPTION
## Summary
- compute rectangular field bounds based on canvas aspect ratio for soccer and football
- render soccer and football fields with rectangular grass fills instead of circular gradients
- keep baseball field rendering unchanged while reusing the new sizing helper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69222cd76b888332b88083389d2fa56f)