### PR TITLE
fix: correct half-sector offset in click/hover hit-detection

### DIFF
--- a/main.js
+++ b/main.js
@@ -1870,10 +1870,14 @@ function getSectorAtPosition(x, y) {
     let angle = Math.atan2(dy, dx);
     angle = angle + Math.PI / 2; // Adjust so sector 0 is at top
     if (angle < 0) angle += Math.PI * 2;
-    
+
     const totalSectors = gameState.sectors.length;
-    const sectorIndex = Math.floor((angle / (Math.PI * 2)) * totalSectors);
-    
+    // Sectors are drawn centered on their angle (see precomputeSectorPaths),
+    // so shift by half a sector before bucketing. Without this, the hit region
+    // is rotated half a sector and clicks/hover land on the neighboring sector.
+    const angleWidth = (Math.PI * 2) / totalSectors;
+    const sectorIndex = Math.floor(((angle + angleWidth / 2) / (Math.PI * 2)) * totalSectors);
+
     return sectorIndex % totalSectors;
 }
 


### PR DESCRIPTION
## What was weird

Interacting with the crowd sectors felt "off": clicking a section would frequently start the wave on (or boost) the **neighboring** section, and the hover highlight landed one sector over.

## Root cause

A half-sector rotational offset between how sectors are **drawn** and how pointer input is **mapped**:

- `precomputeSectorPaths` draws sector `i` **centered** on its angle `(i/N)*2π − π/2`, spanning ±half a sector.
- `getSectorAtPosition` bucketed angles with `floor(angle / 2π * N)`, which treats sector `i` as the range *starting* at its center — rotating the hit region half a sector.

All pointer paths (click, right-click boost, touch tap, hover) funnel through `getSectorAtPosition`, so every one of them inherited the offset.

## Fix

Shift the angle by half a sector width before bucketing so the hit region lines up with the drawn sectors:

```js
const angleWidth = (Math.PI * 2) / totalSectors;
const sectorIndex = Math.floor(((angle + angleWidth / 2) / (Math.PI * 2)) * totalSectors);
```

## Validation

- Round-trip check: sampling points across each drawn sector wedge, the **old** formula misidentified **34/80** points (the left half of every sector); the **fixed** formula maps **80/80** correctly.
- `node --check main.js` passes.
- All 27 Python engine unit tests still pass (engine logic untouched).

## Notes

I checked the rest of the game while investigating — the Python engine and JS mock engine match, the wave-propagation/double-wave logic is sound, and the `dt`/game-loop timing handling is fine. This hit-detection offset was the cause of the weird interaction behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDMJfS7srP3cqtBBrpDHKH)_