### PR TITLE
fix: field offset and unresponsive taps on iPad/iPhone (pixel-ratio mismatch)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1049,8 +1049,8 @@ function getSectorGeometry(sectorId, totalSectors) {
     }
     
     // Fallback for dynamic calculations
-    const centerX = canvas.width / (2 * (window.devicePixelRatio || 1));
-    const centerY = canvas.height / (2 * (window.devicePixelRatio || 1));
+    const centerX = canvas.width / (2 * effectivePixelRatio);
+    const centerY = canvas.height / (2 * effectivePixelRatio);
     const angle = (sectorId / totalSectors) * Math.PI * 2 - Math.PI / 2;
     
     return {
@@ -1217,8 +1217,8 @@ function drawSector(sector, index, totalSectors) {
         (sector.state === 'standing' || sector.state === 'anticipating')) {
         const heightMultiplier = sector.state === 'standing' ? 1.5 : 1.2;
         const extendedRadius = geom.outerRadius + SECTOR_HEIGHT * (heightMultiplier - 1);
-        const centerX = geom.centerX || (canvas.width / (2 * (window.devicePixelRatio || 1)));
-        const centerY = geom.centerY || (canvas.height / (2 * (window.devicePixelRatio || 1)));
+        const centerX = geom.centerX || (canvas.width / (2 * effectivePixelRatio));
+        const centerY = geom.centerY || (canvas.height / (2 * effectivePixelRatio));
         
         ctx.beginPath();
         ctx.arc(centerX, centerY, extendedRadius, geom.startAngle, geom.endAngle);
@@ -1339,7 +1339,7 @@ function drawSoccerField(centerX, centerY, fieldRect) {
 }
 
 function getRectangularField(centerX, centerY, fieldRadius, targetAspect = null) {
-    const devicePixelRatio = window.devicePixelRatio || 1;
+    const devicePixelRatio = effectivePixelRatio;
     const canvasWidth = canvas.width / devicePixelRatio;
     const canvasHeight = canvas.height / devicePixelRatio;
     const canvasAspect = canvasWidth / canvasHeight || 1;
@@ -1546,7 +1546,7 @@ function drawFootballField(centerX, centerY, fieldRect) {
 }
 
 function drawField() {
-    const devicePixelRatio = window.devicePixelRatio || 1;
+    const devicePixelRatio = effectivePixelRatio;
     const centerX = canvas.width / (2 * devicePixelRatio);
     const centerY = canvas.height / (2 * devicePixelRatio);
     const fieldRadius = STADIUM_RADIUS - SECTOR_HEIGHT - 20;
@@ -1575,7 +1575,7 @@ function drawField() {
 function drawEventIndicators() {
     if (!gameState || activeEventIndicators.length === 0) return;
 
-    const devicePixelRatio = window.devicePixelRatio || 1;
+    const devicePixelRatio = effectivePixelRatio;
     const centerX = canvas.width / (2 * devicePixelRatio);
     const centerY = canvas.height / (2 * devicePixelRatio);
 
@@ -1633,7 +1633,7 @@ function drawEventIndicators() {
 function render() {
     if (!gameState) return;
     
-    const devicePixelRatio = window.devicePixelRatio || 1;
+    const devicePixelRatio = effectivePixelRatio;
     const canvasWidth = canvas.width / devicePixelRatio;
     const canvasHeight = canvas.height / devicePixelRatio;
     
@@ -1852,7 +1852,7 @@ function stopGameLoop() {
 function getSectorAtPosition(x, y) {
     if (!gameState) return -1;
     
-    const devicePixelRatio = window.devicePixelRatio || 1;
+    const devicePixelRatio = effectivePixelRatio;
     const centerX = (canvas.width / devicePixelRatio) / 2;
     const centerY = (canvas.height / devicePixelRatio) / 2;
     

--- a/main.js
+++ b/main.js
@@ -1870,10 +1870,14 @@ function getSectorAtPosition(x, y) {
     let angle = Math.atan2(dy, dx);
     angle = angle + Math.PI / 2; // Adjust so sector 0 is at top
     if (angle < 0) angle += Math.PI * 2;
-    
+
     const totalSectors = gameState.sectors.length;
-    const sectorIndex = Math.floor((angle / (Math.PI * 2)) * totalSectors);
-    
+    // Sectors are drawn centered on their angle (see precomputeSectorPaths),
+    // so shift by half a sector before bucketing. Without this, the hit region
+    // is rotated half a sector and clicks/hover land on the neighboring sector.
+    const angleWidth = (Math.PI * 2) / totalSectors;
+    const sectorIndex = Math.floor(((angle + angleWidth / 2) / (Math.PI * 2)) * totalSectors);
+
     return sectorIndex % totalSectors;
 }
 


### PR DESCRIPTION
## Symptoms (from device testing)

On iPad/iPhone:
1. The field rendered shoved into the **top-left**, not centered inside the stadium ring.
2. **Tapping sectors did nothing** — no wave started.

Both worked fine on desktop.

## Root cause

The canvas uses an adaptive pixel ratio. On touch/mobile devices the performance tier drops to `low`/`medium`, so `effectivePixelRatio` becomes **1 or 1.5**, while `window.devicePixelRatio` is **2 or 3**.

- `setupHighDPICanvas` sizes the canvas buffer and scales the 2D context by `effectivePixelRatio`.
- But `drawField`, `drawEventIndicators`, `getSectorGeometry`, `drawSector`, `getRectangularField`, `render`, and `getSectorAtPosition` converted the canvas buffer size back to CSS coordinates using `window.devicePixelRatio`.

When the two ratios diverge, the computed center lands at `rect.width/4` instead of `rect.width/2`:
- the **field** draws at the quarter-left position (the top-left offset in the screenshot), and
- the **tap/click hit-test center** is offset from the drawn ring, so taps fall outside the sector band and `getSectorAtPosition` returns `-1` → no wave.

Desktop is usually the `high` tier (ratios equal), which is why it only misbehaved on iPad/iPhone.

## Fix

Use `effectivePixelRatio` everywhere the context's CSS coordinate space is derived — i.e., the same ratio the context is actually scaled by. The two legitimate reads of `window.devicePixelRatio` (performance-tier scoring and `getEffectivePixelRatio`) are left untouched.

## Validation

- Simulated iPad at low tier (`window.devicePixelRatio=2`, `effectivePixelRatio=1`): ring center `500`; field/hit-test center was `250` (mismatch) before, now `500` (matches the ring).
- `node --check main.js` passes.
- 27/27 Python engine tests pass (engine untouched).

## Relationship to #96

Builds on the merged hit-detection fix (#96). That corrected the half-sector angular offset; this corrects the pixel-ratio center/scale mismatch that specifically broke touch devices.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDMJfS7srP3cqtBBrpDHKH)_