### PR TITLE
fix: remove height:100% from canvas so game controls remain visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,6 @@
 
         #game-canvas {
             width: 100%;
-            height: 100%;
             flex: 1;
             display: block;
             cursor: pointer;


### PR DESCRIPTION
## Problem

After #102 moved `#controls` from `position: absolute` to a flex child below the canvas, the buttons became invisible. The root cause: `#game-canvas` had `height: 100%` in its CSS, which resolves to the full parent container height and overrides the flex layout. This forced the canvas to consume all of the container's height, pushing the controls bar outside the `overflow: hidden` boundary where it's clipped and invisible.

## Fix

Remove `height: 100%` from `#game-canvas`. With only `flex: 1`, the canvas correctly grows to fill the *remaining* height after the controls bar takes its natural space (~60 px). When controls are hidden (`display: none`), the canvas fills the full container as before.

## Test plan

- [x] Start a game — verify the three control buttons (Mascot Moment, Scoreboard Hype, Back to Setup) are visible below the stadium
- [x] Click each button to confirm they are interactive
- [x] Verify the setup screen still fills the full container height (controls are hidden there)
- [x] Check on mobile viewport (< 768px)

https://claude.ai/code/session_018wKbMTfwpSYWjnJcpR85VU

---
_Generated by [Claude Code](https://claude.ai/code/session_018wKbMTfwpSYWjnJcpR85VU)_