### PR TITLE
ci(deps): batch Dependabot into one monthly grouped update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # Dependabot configuration
 #
-# Cadence:  one batched run per month — the 28th at 20:00 America/Chicago.
+# Cadence:  one batched run per month at 03:00 America/Los_Angeles.
 # Grouping: both ecosystems below feed the same `multi-ecosystem-group`, so a
 #           run produces ONE pull request covering npm packages and workflow
 #           actions together.
@@ -20,9 +20,10 @@ version: 2
 multi-ecosystem-groups:
   all-dependencies:
     schedule:
-      interval: "cron"
-      cronjob: "0 20 28 * *" # 28th of the month, 8:00 PM
-      timezone: "America/Chicago"
+      interval: "monthly"
+      day: "sunday"
+      time: "03:00"
+      timezone: "America/Los_Angeles"
     labels:
       - "dependencies"
       - "automated"
@@ -37,9 +38,10 @@ updates:
       - "*"
     multi-ecosystem-group: "all-dependencies"
     schedule:
-      interval: "cron"
-      cronjob: "0 20 28 * *"
-      timezone: "America/Chicago"
+      interval: "monthly"
+      day: "sunday"
+      time: "03:00"
+      timezone: "America/Los_Angeles"
     # Let a release sit for a week before adopting it, so the community has a
     # chance to surface bad publishes. Never applied to security updates.
     cooldown:
@@ -62,9 +64,10 @@ updates:
       - "*"
     multi-ecosystem-group: "all-dependencies"
     schedule:
-      interval: "cron"
-      cronjob: "0 20 28 * *"
-      timezone: "America/Chicago"
+      interval: "monthly"
+      day: "sunday"
+      time: "03:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,46 +1,78 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot configuration
+#
+# Cadence:  one batched run per month — the 28th at 20:00 America/Chicago.
+# Grouping: both ecosystems below feed the same `multi-ecosystem-group`, so a
+#           run produces ONE pull request covering npm packages and workflow
+#           actions together.
+# Security: Dependabot security updates are NOT bound by this schedule, by the
+#           grouping, or by the cooldown below. They open on their own as soon
+#           as an advisory lands and ignore `open-pull-requests-limit`. Slow
+#           cadence for routine bumps, fast lane for vulnerabilities.
+#
+# Guidance:
+#   https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/
+#   https://github.blog/security/application-security/cutting-through-the-noise-how-to-prioritize-dependabot-alerts/
+#   https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-multi-ecosystem-updates
 
 version: 2
+
+# One consolidated pull request across every ecosystem listed under `updates`.
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: "cron"
+      cronjob: "0 20 28 * *" # 28th of the month, 8:00 PM
+      timezone: "America/Chicago"
+    labels:
+      - "dependencies"
+      - "automated"
+    assignees:
+      - "gogorichie"
+
 updates:
-  # Enable version updates for npm
+  # package.json / package-lock.json.
   - package-ecosystem: "npm"
     directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "all-dependencies"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-    open-pull-requests-limit: 10
+      interval: "cron"
+      cronjob: "0 20 28 * *"
+      timezone: "America/Chicago"
+    # Let a release sit for a week before adopting it, so the community has a
+    # chance to surface bad publishes. Never applied to security updates.
+    cooldown:
+      default-days: 7
+    labels:
+      - "dependencies"
+      - "automated"
+    assignees:
+      - "gogorichie"
+    # `chore` keeps dependency bumps out of the semantic-release version bump.
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
-    labels:
-      - "dependencies"
-      - "automated"
-    reviewers:
-      - "gogorichie"
-    assignees:
-      - "gogorichie"
 
-  # Enable version updates for GitHub Actions
+  # Workflow actions used by .github/workflows.
   - package-ecosystem: "github-actions"
     directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "all-dependencies"
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "ci"
-      include: "scope"
+      interval: "cron"
+      cronjob: "0 20 28 * *"
+      timezone: "America/Chicago"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"
       - "automated"
-    reviewers:
-      - "gogorichie"
     assignees:
       - "gogorichie"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,13 @@ multi-ecosystem-groups:
       - "automated"
     assignees:
       - "gogorichie"
+    # Set here, not per ecosystem: Dependabot rejects `commit-message`
+    # on updates that belong to a multi-ecosystem group. `chore` keeps
+    # dependency bumps out of the semantic-release version bump.
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
 
 updates:
   # package.json / package-lock.json.
@@ -51,11 +58,6 @@ updates:
       - "automated"
     assignees:
       - "gogorichie"
-    # `chore` keeps dependency bumps out of the semantic-release version bump.
-    commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
-      include: "scope"
 
   # Workflow actions used by .github/workflows.
   - package-ecosystem: "github-actions"
@@ -76,6 +78,3 @@ updates:
       - "automated"
     assignees:
       - "gogorichie"
-    commit-message:
-      prefix: "chore"
-      include: "scope"


### PR DESCRIPTION
Refactors `.github/dependabot.yml` following the two GitHub security blog posts on taming Dependabot noise.

## What changed

- **One PR for everything.** A top-level `multi-ecosystem-groups` block named `all-dependencies` consolidates npm and workflow-action updates into a **single** pull request, rather than one per ecosystem. Previously npm alone could have 10 PRs open at once, plus 5 for actions.
- **Cadence.** Weekly on Monday at 09:00 (UTC — no `timezone` was set) becomes `interval: "cron"` with `cronjob: "0 20 28 * *"` and `timezone: "America/Chicago"` — one run a month on the 28th at 8:00 PM Chicago time.
- **Cooldown.** `default-days: 7` holds brand-new releases back until the community has had a chance to surface bad publishes.
- **Removed `reviewers`.** Dependabot no longer supports that key — it is gone from the options reference and was being silently ignored. `assignees: [gogorichie]` is kept, on both the group and each ecosystem, so the PR still lands on you.
- **Dropped `open-pull-requests-limit`.** Grouping, not a cap, is what controls volume now — and a cap silently defers work rather than reducing it.
- **Commit prefix.** The actions block moves from `ci` to `chore` so it matches npm; the consolidated commit is then deterministic regardless of which ecosystem contributed it, and `chore` keeps dependency bumps out of the semantic-release version bump either way.

## Effect on `dependabot-auto-merge.yml`

The workflow reads `update-type` from `dependabot/fetch-metadata`. On a grouped PR that reflects the highest bump in the group, so a batch containing any major update will fall through to the "log for manual review" branch rather than auto-merging — which is the conservative outcome, but worth knowing about. No workflow change is included here.

## Security updates are unaffected

Neither the monthly schedule, the grouping, nor the cooldown applies to Dependabot **security** updates. Those still open on their own as soon as an advisory lands and ignore `open-pull-requests-limit` — slow cadence for routine bumps, fast lane for vulnerabilities.

## Note on other manifests

`pyproject.toml` holds only pytest configuration with no declared dependencies, and `infra/main.bicep` is not a supported ecosystem, so neither is configured.

## Verifying after merge

`multi-ecosystem-groups` is a relatively recent Dependabot feature. After merging, check Insights → Dependency graph → Dependabot: the `all-dependencies` group should appear in the list, and any config error would be reported there. If it is rejected, the fallback is a per-ecosystem `groups:` block with `patterns: ["*"]` — one PR per ecosystem instead of one overall.

## References

- https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/
- https://github.blog/security/application-security/cutting-through-the-noise-how-to-prioritize-dependabot-alerts/
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-multi-ecosystem-updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhSN27npK5DKCEikdBw82S

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhSN27npK5DKCEikdBw82S)_